### PR TITLE
Implement Animations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ add_library(LilacStyle SHARED
     lilacstyle.h
     lilac.cpp
     lilac.h
+    lilacanimationmanager.h
+    lilacanimationmanager.cpp
 )
 
 target_link_libraries(LilacStyle PRIVATE Qt6::Widgets)

--- a/lilac.h
+++ b/lilac.h
@@ -243,6 +243,7 @@ struct Config {
 
     static constexpr int progressBarLabelHorizontalPadding = 3;  // around the label, horizontal when the progressbar is horizontal
     static constexpr int progressBarThickness = 6;
+    static constexpr qreal progressBarBusyIndicatorLen = 0.25;  // value between 0 and 1 setting how large part of the entire bar should be the indicator
 
     static constexpr int treeIndicatorArrowSize = 10;
     static constexpr int treeIndicatorArrowLineMargin = 4;   // the distance between the arrow and start of the line
@@ -262,6 +263,15 @@ struct Config {
     static constexpr int dockHeaderControlsHeight = 12;  // for the close and float buttons
 
     static constexpr int tooltipOpacity = 235;
+
+    // animation constants
+    /* durations are in miliseconds
+     *
+     * the durations are only a default value,
+     * in the end they may be faster/slower depending on the global animation speed
+     */
+    static constexpr int progressBarBusyDuration = 1000;
+    static constexpr int scrollBarShowDuration = 40;
 
     // methods
 #if HAS_SETTINGS

--- a/lilac.h
+++ b/lilac.h
@@ -270,6 +270,7 @@ struct Config {
      * the durations are only a default value,
      * in the end they may be faster/slower depending on the global animation speed
      */
+    static constexpr int defaultAnimationSpeed = 1;  // if >=0 then the animations are instant, if settings are enabled this value will be overriden
     static constexpr int progressBarBusyDuration = 1000;
     static constexpr int scrollBarShowDuration = 40;
 

--- a/lilac.kcfg
+++ b/lilac.kcfg
@@ -15,5 +15,9 @@
             <label>Whether to make checkboxes a circle or a rounded rectangle.</label>
             <default>false</default>
         </entry>
+        <entry name="AnimationSpeed" type="Double">
+            <label>Animation speed, if the the value is less or equal to 0 the animations are instant.</label>
+            <default>1</default>
+        </entry>
     </group>
 </kcfg>

--- a/lilacanimationmanager.cpp
+++ b/lilacanimationmanager.cpp
@@ -7,15 +7,10 @@
 namespace Lilac {
 
 AnimationManager::AnimationManager() {
-    setAnimationSpeed(Config::defaultAnimationSpeed);
+    setGlobalAnimationSpeed(Config::defaultAnimationSpeed);
 }
 
 AnimationManager::~AnimationManager() {
-    for (auto i = animations.begin(); i != animations.end(); i++) {
-        if (i.value()) {
-            delete i.value();
-        }
-    }
 }
 
 void AnimationManager::remove(const QWidget* w) {
@@ -28,7 +23,7 @@ void AnimationManager::remove(const QWidget* w) {
     }
 }
 
-void AnimationManager::setAnimationSpeed(const double speed) {
+void AnimationManager::setGlobalAnimationSpeed(const double speed) {
     if (speed <= 0) {
         durationMultiplier = 0;
         return;
@@ -40,12 +35,12 @@ void AnimationManager::setAnimationSpeed(const double speed) {
 QVariantAnimation* AnimationManager::getOrCreateAnimation(const QWidget* w, const QVariant& start, const QVariant& end, const int duration, const QVariantAnimation::Direction direction, bool infinite, bool independentOfAnimationSpeed) {
     QWidget* widget = const_cast<QWidget*>(w);
     if (!animations.contains(widget)) {
-        animations.insert(widget, QPointer<QVariantAnimation>(new QVariantAnimation(widget)));
+        animations.insert(widget, QPointer<QVariantAnimation>(new QVariantAnimation(this)));
     }
     QVariantAnimation* animation;
     animation = animations[widget].get();
 
-    connect(widget, &QVariantAnimation::destroyed, this, [=]() { remove(widget); });
+    connect(widget, &QWidget::destroyed, this, [=]() { remove(widget); });
     connect(animation, SIGNAL(valueChanged(QVariant)), widget, SLOT(update()));
 
     animation->setStartValue(start);

--- a/lilacanimationmanager.cpp
+++ b/lilacanimationmanager.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 zalesyc and the lilac-qt contributors
+
+#include "lilacanimationmanager.h"
+// #define T int
+namespace Lilac {
+
+AnimationManager::AnimationManager() {
+}
+
+QVariant AnimationManager::getCurrentValue(const QWidget* w, const QVariant& start, const QVariant& end, bool infinite) {
+    return getOrCreateAnimation(w, start, end, infinite)->currentValue();
+}
+
+void AnimationManager::remove(const QWidget* w) {
+    qDebug() << "destroying" << w << animations.contains(w);
+    if (!w || !animations.contains(w)) {
+        return;
+    }
+    const QPointer<QVariantAnimation> ptr = animations.take(w);
+    if (ptr) {
+        delete ptr;
+    }
+}
+
+QVariantAnimation* AnimationManager::getOrCreateAnimation(const QWidget* w, const QVariant& start, const QVariant& end, bool infinite) {
+    QWidget* widget = const_cast<QWidget*>(w);
+
+    if (animations.contains(widget)) {
+        return animations[widget].get();
+    }
+
+    QVariantAnimation* animation;
+    animations.insert(widget, QPointer<QVariantAnimation>(new QVariantAnimation(widget)));
+    animation = animations[widget].get();
+
+    connect(widget, &QVariantAnimation::destroyed, this, [=]() { remove(widget); });
+    connect(animation, SIGNAL(valueChanged(QVariant)), widget, SLOT(update()));
+
+    animation->setStartValue(start);
+    animation->setEndValue(end);
+    animation->setLoopCount(infinite ? -1 : 0);
+    animation->setDuration(2000);
+    animation->start();
+
+    return animation;
+}
+
+}  // namespace Lilac

--- a/lilacanimationmanager.h
+++ b/lilacanimationmanager.h
@@ -19,15 +19,18 @@ class AnimationManager : QObject {
 
     // w may not be nullptr
     template <typename T>
-    T getCurrentValue(const QWidget* w, const T& start, const T& end, const int duration, const QVariantAnimation::Direction direction = QVariantAnimation::Forward, bool infinite = false) {
-        return getOrCreateAnimation(w, start, end, duration, direction, infinite)->currentValue().template value<T>();
+    T getCurrentValue(const QWidget* w, const T& start, const T& end, const int duration, const QVariantAnimation::Direction direction = QVariantAnimation::Forward, bool infinite = false, bool independentOfAnimationSpeed = false) {
+        if (!independentOfAnimationSpeed && durationMultiplier == 0) {
+            return end;
+        }
+        return getOrCreateAnimation(w, start, end, duration, direction, infinite, independentOfAnimationSpeed)->currentValue().template value<T>();
     }
 
     // this returns only the value of the animation, if the animation doesnt exist it returns defaultValue
     // T must be the same as where the animation was defined, othervise defaultValue is returned
     template <typename T>
     T getOnlyValue(const QWidget* w, const T defaultValue = T()) {
-        if (!w || !animations.contains(w)) {
+        if (!w || !animations.contains(w) || durationMultiplier == 0) {
             return defaultValue;
         }
         const QVariant variant = animations[w]->currentValue();
@@ -39,11 +42,14 @@ class AnimationManager : QObject {
 
     void remove(const QWidget* w);
 
+    void setAnimationSpeed(const double speed);
+
    private:
-    QVariantAnimation* getOrCreateAnimation(const QWidget* w, const QVariant& start, const QVariant& end, const int duration, const QVariantAnimation::Direction direction, bool infinite);
+    QVariantAnimation* getOrCreateAnimation(const QWidget* w, const QVariant& start, const QVariant& end, const int duration, const QVariantAnimation::Direction direction, bool infinite, bool independentOfAnimationSpeed);
 
    private:
     QHash<const QWidget*, QPointer<QVariantAnimation>> animations;
+    double durationMultiplier = 1;  // global amimation speed, default value set in constructor
 };
 
 }  // namespace Lilac

--- a/lilacanimationmanager.h
+++ b/lilacanimationmanager.h
@@ -42,7 +42,7 @@ class AnimationManager : QObject {
 
     void remove(const QWidget* w);
 
-    void setAnimationSpeed(const double speed);
+    void setGlobalAnimationSpeed(const double speed);
 
    private:
     QVariantAnimation* getOrCreateAnimation(const QWidget* w, const QVariant& start, const QVariant& end, const int duration, const QVariantAnimation::Direction direction, bool infinite, bool independentOfAnimationSpeed);

--- a/lilacanimationmanager.h
+++ b/lilacanimationmanager.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 zalesyc and the lilac-qt contributors
+
+#pragma once
+
+#include <QHash>
+#include <QPointer>
+#include <QVariantAnimation>
+#include <QWidget>
+
+namespace Lilac {
+
+class AnimationManager : QObject {
+    Q_OBJECT
+
+   public:
+    AnimationManager();
+
+    // w may not be nullptr
+    QVariant getCurrentValue(const QWidget* w, const QVariant& start, const QVariant& end, bool infinite = false);
+
+    void remove(const QWidget* w);
+
+   private:
+    QVariantAnimation* getOrCreateAnimation(const QWidget* w, const QVariant& start, const QVariant& end, bool infinite = false);
+
+   private:
+    QHash<const QWidget*, QPointer<QVariantAnimation>> animations;
+};
+
+}  // namespace Lilac

--- a/lilacanimationmanager.h
+++ b/lilacanimationmanager.h
@@ -15,14 +15,32 @@ class AnimationManager : QObject {
 
    public:
     AnimationManager();
+    ~AnimationManager();
 
     // w may not be nullptr
-    QVariant getCurrentValue(const QWidget* w, const QVariant& start, const QVariant& end, bool infinite = false);
+    template <typename T>
+    T getCurrentValue(const QWidget* w, const T& start, const T& end, const int duration, const QVariantAnimation::Direction direction = QVariantAnimation::Forward, bool infinite = false) {
+        return getOrCreateAnimation(w, start, end, duration, direction, infinite)->currentValue().template value<T>();
+    }
+
+    // this returns only the value of the animation, if the animation doesnt exist it returns defaultValue
+    // T must be the same as where the animation was defined, othervise defaultValue is returned
+    template <typename T>
+    T getOnlyValue(const QWidget* w, const T defaultValue = T()) {
+        if (!w || !animations.contains(w)) {
+            return defaultValue;
+        }
+        const QVariant variant = animations[w]->currentValue();
+        if (!variant.template canConvert<T>()) {
+            return defaultValue;
+        }
+        return variant.template value<T>();
+    }
 
     void remove(const QWidget* w);
 
    private:
-    QVariantAnimation* getOrCreateAnimation(const QWidget* w, const QVariant& start, const QVariant& end, bool infinite = false);
+    QVariantAnimation* getOrCreateAnimation(const QWidget* w, const QVariant& start, const QVariant& end, const int duration, const QVariantAnimation::Direction direction, bool infinite);
 
    private:
     QHash<const QWidget*, QPointer<QVariantAnimation>> animations;

--- a/lilacstyle.cpp
+++ b/lilacstyle.cpp
@@ -25,6 +25,7 @@
 namespace Lilac {
 
 Style::Style() {
+    animationMgr = new Lilac::AnimationManager();
     settingsChanged();
 #if HAS_DBUS
     auto dbus = QDBusConnection::sessionBus();
@@ -50,7 +51,6 @@ Style::Style() {
         this,
         SLOT(settingsChanged()));
 #endif
-    animationMgr = new Lilac::AnimationManager();
 };
 
 Style::~Style() {
@@ -1206,7 +1206,7 @@ void Style::drawControl(QStyle::ControlElement element, const QStyleOption* opt,
                     p->setBrush(getBrush(bar->palette, Color::progressBarIndicator, state));
 
                     const qreal dashLen = (horizontal ? bar->rect.width() : bar->rect.height()) * Config::progressBarBusyIndicatorLen;
-                    const qreal progress = widget ? animationMgr->getCurrentValue<qreal>(widget, 0.0, 2 * M_PI, config.progressBarBusyDuration, QVariantAnimation::Forward, true) : 0;
+                    const qreal progress = widget ? animationMgr->getCurrentValue<qreal>(widget, 0.0, 2 * M_PI, config.progressBarBusyDuration, QVariantAnimation::Forward, true, true) : 0;
                     const qreal position = (qCos((progress) + M_PI) + 1) / 2.0;
 
                     if (horizontal) {
@@ -3054,6 +3054,7 @@ void Style::settingsChanged() {
     auto settings = LilacSettings::self();
     settings->load();
     config.initFromSettings(settings);
+    animationMgr->setAnimationSpeed(settings->animationSpeed());
 #endif
 }
 

--- a/lilacstyle.cpp
+++ b/lilacstyle.cpp
@@ -25,7 +25,6 @@
 namespace Lilac {
 
 Style::Style() {
-    animationMgr = new Lilac::AnimationManager();
     settingsChanged();
 #if HAS_DBUS
     auto dbus = QDBusConnection::sessionBus();
@@ -54,7 +53,6 @@ Style::Style() {
 };
 
 Style::~Style() {
-    delete animationMgr;
 }
 
 void Style::drawComplexControl(QStyle::ComplexControl control, const QStyleOptionComplex* opt, QPainter* p, const QWidget* widget) const {
@@ -3054,7 +3052,7 @@ void Style::settingsChanged() {
     auto settings = LilacSettings::self();
     settings->load();
     config.initFromSettings(settings);
-    animationMgr->setAnimationSpeed(settings->animationSpeed());
+    animationMgr->setGlobalAnimationSpeed(settings->animationSpeed());
 #endif
 }
 

--- a/lilacstyle.cpp
+++ b/lilacstyle.cpp
@@ -782,7 +782,7 @@ void Style::drawControl(QStyle::ControlElement element, const QStyleOption* opt,
             const qreal animationProgress = animationMgr->getOnlyValue<qreal>(widget, state.enabled && state.hovered ? 1 : 0);
 
             QRect originalRect;
-            QRect rect;
+            QRectF rect;
             if (horizontal) {
                 originalRect = opt->rect.adjusted(0, 1, 0, 0);  // the +1 is for the separator line above the hovered separator width
                 rect = originalRect;

--- a/lilacstyle.h
+++ b/lilacstyle.h
@@ -7,6 +7,7 @@
 #include <QStyle>
 #include <QStyleOption>
 #include <QWidget>
+#include <memory>
 
 #include "lilac.h"
 #include "lilacanimationmanager.h"
@@ -35,7 +36,7 @@ class Style : public SuperStyle {
 
    protected:
     Lilac::Config config;
-    Lilac::AnimationManager* animationMgr;
+    std::unique_ptr<Lilac::AnimationManager> animationMgr = std::make_unique<AnimationManager>();
 
    public slots:
     void settingsChanged();

--- a/lilacstyle.h
+++ b/lilacstyle.h
@@ -9,6 +9,7 @@
 #include <QWidget>
 
 #include "lilac.h"
+#include "lilacanimationmanager.h"
 
 namespace Lilac {
 
@@ -18,6 +19,7 @@ class Style : public SuperStyle {
    public:
     QString name() const { return QStringLiteral("Lilac"); }
     Style();
+    ~Style();
     void drawComplexControl(QStyle::ComplexControl control, const QStyleOptionComplex* opt, QPainter* p, const QWidget* widget = nullptr) const override;
     void drawControl(QStyle::ControlElement element, const QStyleOption* opt, QPainter* p, const QWidget* widget = nullptr) const override;
     void drawPrimitive(QStyle::PrimitiveElement element, const QStyleOption* opt, QPainter* p, const QWidget* widget = nullptr) const override;
@@ -33,6 +35,7 @@ class Style : public SuperStyle {
 
    protected:
     Lilac::Config config;
+    Lilac::AnimationManager* animationMgr;
 
    public slots:
     void settingsChanged();

--- a/settings/lilacsettingsapp.cpp
+++ b/settings/lilacsettingsapp.cpp
@@ -21,6 +21,7 @@ SettingsApp::SettingsApp(QWidget* parent)
 
     connect(ui->radiusSpin, &QSpinBox::valueChanged, this, &SettingsApp::widgetChanged);
     connect(ui->circleCheckCheckBox, &QCheckBox::clicked, this, &SettingsApp::widgetChanged);
+    connect(ui->animationSpeedSlider, &QSlider::valueChanged, this, [this](int value) { ui->animationValue->setText(QString::number(value / 10.0)); });
 
     setFromSettings();
 }
@@ -34,6 +35,7 @@ void SettingsApp::defaults() {
 void SettingsApp::save() {
     settings->setCornerRadius(ui->radiusSpin->value());
     settings->setCircleCheckBox(ui->circleCheckCheckBox->isChecked());
+    settings->setAnimationSpeed(ui->animationSpeedSlider->value() / 10.0);
     settings->save();
 #if HAS_DBUS
     auto msg = QDBusMessage::createSignal(
@@ -48,6 +50,7 @@ void SettingsApp::setFromSettings() {
     settings->load();
     ui->radiusSpin->setValue(settings->cornerRadius());
     ui->circleCheckCheckBox->setChecked(settings->circleCheckBox());
+    ui->animationSpeedSlider->setValue(settings->animationSpeed() * 10.0);
 }
 
 SettingsApp::~SettingsApp() {

--- a/settings/lilacsettingsapp.ui
+++ b/settings/lilacsettingsapp.ui
@@ -42,6 +42,34 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="animationSpeedLabel">
+     <property name="text">
+      <string>Animation Speed</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QSlider" name="animationSpeedSlider">
+       <property name="maximum">
+        <number>99</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="animationValue">
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
This MR implements the ability to create animations/transitions

Although there are only 2 animations: busy progress bar and showing of the scrollbar groove, this MR mainly creates the framework to create more animations in the future. 

The animations are implemented using QVariantAnimation animations stored in a QMap under their respective widget.
There are some limitations, like not allowing to have more then one animation per widget, or not being able to animate widgets that don't provide the widget parameter in the draw functions. 

The animation framework is based on this blog post: [https://www.olivierclero.com/code/custom-qstyle/#animations](https://www.olivierclero.com/code/custom-qstyle/#animations)